### PR TITLE
3DSでの午後の動作に対応

### DIFF
--- a/PokeRNG/Calc5GenSeed.cpp
+++ b/PokeRNG/Calc5GenSeed.cpp
@@ -126,5 +126,9 @@ template u64 Calc5GenSeed::operator()<ROMType::B1Ja>(const Parameters5Gen<ROMTyp
 template u64 Calc5GenSeed::operator()<ROMType::W1Ja>(const Parameters5Gen<ROMType::W1Ja>&);
 template u64 Calc5GenSeed::operator()<ROMType::B2Ja>(const Parameters5Gen<ROMType::B2Ja>&);
 template u64 Calc5GenSeed::operator()<ROMType::W2Ja>(const Parameters5Gen<ROMType::W2Ja>&);
+template u64 Calc5GenSeed::operator()<ROMType::B1JaDSi>(const Parameters5Gen<ROMType::B1JaDSi>&);
+template u64 Calc5GenSeed::operator()<ROMType::W1JaDSi>(const Parameters5Gen<ROMType::W1JaDSi>&);
+template u64 Calc5GenSeed::operator()<ROMType::B2JaDSi>(const Parameters5Gen<ROMType::B2JaDSi>&);
+template u64 Calc5GenSeed::operator()<ROMType::W2JaDSi>(const Parameters5Gen<ROMType::W2JaDSi>&);
 
 } // end PokeRNG

--- a/PokeRNG/Calc5GenSeed.cpp
+++ b/PokeRNG/Calc5GenSeed.cpp
@@ -56,7 +56,7 @@ u64 Calc5GenSeed::operator() (const Parameters5Gen<Constant>& param) {
                (to_bcd(param.get_day()) << 8) |
                 param.get_week();
         W[9] = ((to_bcd(param.get_hour()) |
-               ((12<=param.get_hour())<<6)) << 24) |
+               ((!param.get_is3ds()&&12<=param.get_hour())<<6)) << 24) |
                (to_bcd(param.get_minute()) << 16) |
                (to_bcd(param.get_second()) << 8);
         W[10] = 0x00000000;

--- a/PokeRNG/Parameters5Gen.cpp
+++ b/PokeRNG/Parameters5Gen.cpp
@@ -7,7 +7,7 @@
 
 namespace PokeRNG {
 template<typename Constant>
-Parameters5Gen<Constant>::Parameters5Gen() : nazo1(Constant::nazo1), nazo2(Constant::nazo2), nazo3(Constant::nazo3), nazo4(Constant::nazo4), nazo5(Constant::nazo5), vcount(Constant::vcount), gxstat(Constant::gxstat), frame(Constant::frame), timer0_min(Constant::timer0_min), timer0_max(Constant::timer0_max), timer0(timer0_min), key(0x2fff), mac_addr1(0), mac_addr2(0), mac_addr3(0), mac_addr4(0), mac_addr5(0), mac_addr6(0), year(0), month(0), day(0), hour(0), minute(0), second(0) { }
+Parameters5Gen<Constant>::Parameters5Gen() : nazo1(Constant::nazo1), nazo2(Constant::nazo2), nazo3(Constant::nazo3), nazo4(Constant::nazo4), nazo5(Constant::nazo5), vcount(Constant::vcount), gxstat(Constant::gxstat), frame(Constant::frame), timer0_min(Constant::timer0_min), timer0_max(Constant::timer0_max), timer0(timer0_min), key(0x2fff), mac_addr1(0), mac_addr2(0), mac_addr3(0), mac_addr4(0), mac_addr5(0), mac_addr6(0), year(0), month(0), day(0), hour(0), minute(0), second(0), is3ds(false) { }
 
 template<typename Constant>
 void Parameters5Gen<Constant>::set_mac_addr(u32 m1, u32 m2, u32 m3, u32 m4, u32 m5, u32 m6) {
@@ -112,6 +112,11 @@ void Parameters5Gen<Constant>::set_timer0_min(u32 timer0_min_) {
 template<typename Constant>
 void Parameters5Gen<Constant>::set_timer0_max(u32 timer0_max_) {
     timer0_max = timer0_max_;
+}
+
+template<typename Constant>
+void Parameters5Gen<Constant>::set_is3ds(bool is3ds_) {
+    is3ds = is3ds_;
 }
 
 template<typename Constant>
@@ -238,6 +243,11 @@ u32 Parameters5Gen<Constant>::get_timer0_min() const {
 template<typename Constant>
 u32 Parameters5Gen<Constant>::get_timer0_max() const {
     return timer0_max;
+}
+
+template<typename Constant>
+bool Parameters5Gen<Constant>::get_is3ds() const {
+    return is3ds;
 }
 
 template class Parameters5Gen<ROMType::None>;

--- a/PokeRNG/Parameters5Gen.cpp
+++ b/PokeRNG/Parameters5Gen.cpp
@@ -255,5 +255,9 @@ template class Parameters5Gen<ROMType::B1Ja>;
 template class Parameters5Gen<ROMType::W1Ja>;
 template class Parameters5Gen<ROMType::B2Ja>;
 template class Parameters5Gen<ROMType::W2Ja>;
+template class Parameters5Gen<ROMType::B1JaDSi>;
+template class Parameters5Gen<ROMType::W1JaDSi>;
+template class Parameters5Gen<ROMType::B2JaDSi>;
+template class Parameters5Gen<ROMType::W2JaDSi>;
 
 } // end PokeRNG

--- a/PokeRNG/Parameters5Gen.hpp
+++ b/PokeRNG/Parameters5Gen.hpp
@@ -45,6 +45,8 @@ private:
     u32 minute;
     u32 second;
 
+    bool is3ds;
+
 
 public:
     Parameters5Gen();
@@ -74,6 +76,8 @@ public:
 
     void set_timer0_min(u32);
     void set_timer0_max(u32);
+
+    void set_is3ds(bool);
 
 
     u32 get_mac_addr1() const;
@@ -106,6 +110,8 @@ public:
 
     u32 get_timer0_min() const;
     u32 get_timer0_max() const;
+
+    bool get_is3ds() const;
 
 };
 


### PR DESCRIPTION
3DSでは午後であってもhourに0x40を足さないため、それに対応しました。
Parameters5Genにis3dsというフィールドを追加しています。

(dsiプルリクエストのときにParameters5GenとCalc5GenSeedを編集し忘れていたのでその対応のコミットも含めています)